### PR TITLE
fix: fix unescaped semicolon

### DIFF
--- a/compat-tests.el
+++ b/compat-tests.el
@@ -251,7 +251,7 @@
   ;; ;; Modifiers:
   (should-equal (key-parse "C-x") [?\C-x])
   (should-equal (key-parse "C-x a") [?\C-x ?a])
-  (should-equal (key-parse "C-;") [?\C-;])
+  (should-equal (key-parse "C-;") [?\C-?\;])
   (should-equal (key-parse "C-a") [?\C-a])
   (should-equal (key-parse "C-c SPC") [?\C-c ?\s])
   (should-equal (key-parse "C-c TAB") [?\C-c ?\t])


### PR DESCRIPTION
fix unescaped semicolon.

* `error: compat-tests.el:0:0: error: scan-error: (Unbalanced parentheses 9333 92132)`