### PR TITLE
Unbreak test package-get-version

### DIFF
--- a/compat-tests.el
+++ b/compat-tests.el
@@ -56,6 +56,7 @@
 (require 'time-date)
 (require 'image)
 (require 'text-property-search nil t)
+(require 'find-func)
 
 ;; Setup tramp mock
 (require 'tramp)
@@ -93,7 +94,13 @@
     (setq list (funcall sym list "first" 1 #'string=))
     (should-equal (compat-call plist-get list "first" #'string=) 1)))
 
-(defconst compat-tests--version (package-get-version))
+(defconst compat-tests--version (let ((mainfile (find-library-name "compat.el")))
+				  (when (file-readable-p mainfile)
+				    (require 'lisp-mnt)
+				    (with-temp-buffer
+				      (insert-file-contents mainfile)
+				      (or (lm-header "package-version")
+					  (lm-header "version"))))))
 (ert-deftest package-get-version ()
   (should (stringp compat-tests--version))
   (should-equal 29 (car (version-to-list compat-tests--version))))


### PR DESCRIPTION
Hello Daniel,

The test `package-get-version` can fail if the directory storing the elisp files is not called "compat".

The steps to reproduce should be the following : 

```shell
git clone https://github.com/emacs-compat/compat randomdirectoryname
cd randomdirectoryname
make test
```

Only this : 

```shell
git clone https://github.com/emacs-compat/compat
cd compat
make test
```

works. This is because `package-get-version` relies as a last resort on the directory name to get the "good" main file of the package.

I propose to set the name of the "main file" from which to read the version number ourselves. It is always the exact source file providing the compat feature required by the tests, so it should work every time.

Then we can get the version number of the package like `package-get-version` would.

Of course, there are probably multiple other ways to get the version number of the package, like some user-facing function. This is just one way of doing it.

Best,

Aymeric