### PR TITLE
LOW PRIORITY : Unbreak test for 32-bit architectures

### DIFF
--- a/compat-tests.el
+++ b/compat-tests.el
@@ -2036,7 +2036,7 @@
   (should-equal 2 (string-search "a\U00010f98z" "a\U00010f98a\U00010f98z"))
   (should-error (string-search "a" "abc" -1) :type '(args-out-of-range -1))
   (should-error (string-search "a" "abc" 4) :type '(args-out-of-range 4))
-  (should-error (string-search "a" "abc" 100000000000) :type '(args-out-of-range 100000000000))
+  (should-error (string-search "a" "abc" most-positive-fixnum) :type '(args-out-of-range most-positive-fixnum))
   (should-not (string-search "a" "aaa" 3))
   (should-not (string-search "aa" "aa" 1))
   (should-not (string-search "\0" ""))


### PR DESCRIPTION
Hello Daniel,

This is a low priority fix, and needs not be tackled immediately. I'm just posting it now so that I don't forget about it later.

Debian's CI system caught a test failure on 32-bit architectures : the failing test expects the argument `100000000000` to be out of range. However, on 32-bit architectures, since `100000000000` is not a `fixnum`, but a `bignum`, the error produced is `wrong-type-argument` : in the primitive `string-search`, the correct type is tested **before** the correct range.

There are several ways to solve this :
* extending the kind of accepted errors to include `wrong-type-argument`.
* replacing `100000000000` with `most-positive-fixnum`, which is always a `fixnum`, and will therefore always produce the right error. This is what I did here, but you might prefer the other solution.

I'm also forwarding you this fix since github's CI could not possibly have caught this failure, for it runs the tests on only one architecture, x86_64.

Best,

Aymeric