### PR TITLE
Make `make check` work with BSD grep and sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,15 @@ clean:
 
 check:
 	@echo "Check: All definitions must link to a test"
-	@! (grep -P "^\\(compat-(def|guard)" *.el | grep -v "compat-tests:")
+	@! (grep -E "^\\(compat-(def|guard)" *.el | grep -v "compat-tests:")
 	@echo "Check: All definitions must use compat-def* macros"
-	@! (grep -P "^\\(def" compat-[0-9][0-9].el)
+	@! (grep -E "^\\(def" compat-[0-9][0-9].el)
 	@echo "Check: Test links must be valid"
 	@grep "(ert-deftest compat-" compat-tests.el | \
 		grep -E -v "\\(ert-deftest compat-(function|loaded-features) \\(\\)" | \
 		sed -E "s/\\(ert-deftest compat-| \\(\\).*//g" | sort > /tmp/compat-defs
 	@grep "compat-tests:" *.el | \
-		sed -E "s/.*<compat-tests:(.+?)>|.*\\[\\[compat-tests:(.+?)\\]\\]/\1\2/g" | \
+		sed -E "s/.*<compat-tests:([^)]+)>|.*\\[\\[compat-tests:([^)]+)\\]\\]/\1\2/g" | \
 		sort | uniq > /tmp/compat-links
 	@ (diff /tmp/compat-defs /tmp/compat-defs)
 


### PR DESCRIPTION
Remove use of some GNU-specific features: grep -P, non-greedy repetition in sed.
