### PR TITLE
fix(compat.el): Package-Requires "seq" = 2.3 -> 2.23

### DIFF
--- a/compat.el
+++ b/compat.el
@@ -6,7 +6,7 @@
 ;; Maintainer: Daniel Mendler <mail@daniel-mendler.de>, Compat Development <~pkal/compat-devel@lists.sr.ht>
 ;; Version: 29.1.4.3
 ;; URL: https://github.com/emacs-compat/compat
-;; Package-Requires: ((emacs "24.4") (seq "2.3"))
+;; Package-Requires: ((emacs "24.4") (seq "2.23"))
 ;; Keywords: lisp, maint
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
I believe there was an unfortunate typo for the `Package-Requires:` in `compat.el` and it was probably intended to be `(seq "2.23")` [which exists and was released on 2021-Sep-25](https://elpa.gnu.org/packages/seq.html), instead of `(seq "2.3")` which [does not exist and cannot be met](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/emacs-lisp/seq.el).

If the intent was instead to depend on `seq=2.24`, please ignore this pull request. If you prefer that I open another one if that's the case let me know.

### Goal

Set the correct requirement for `seq`.

### Issue with the dependency

It seems that in Emacs-29.1, given new behavior of `package-install` when considering builtin packages, it has the unfortunate consequence of forcing the package `seq` to be downloaded and install from ELPA, _even when it shouldn't_ (because Emacs-29.1 already has the latest version).

Other versions of Emacs seem unaffected.

#### Steps to reproduce

The step below demonstrate that installing `compat` affects the computation of dependencies in `package.el`, causing it to return `seq` as part of the list of packages to install (even if it's not necessary), as demonstrated when `compat` is not present.

When compat is not installed:
```
emacs --no-site-file --batch \
--eval "(progn \
  (require 'package) \
  (setq package-user-dir \"~/tmp-cache\") \
  (add-to-list 'package-archives '(\"melpa\" . \"http://melpa.org/packages/\")) \
  (add-to-list 'package-archives '(\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\")) \
  (package-initialize) \
  (package-refresh-contents) \
  (print (mapcar #'package-desc-name (package-compute-transaction () (list (list 'git-commit))))))"
...

(compat with-editor transient git-commit)
```
With compat being installed first, `package.el` now requires `seq` to be downloaded too:
```
emacs --no-site-file --batch \
--eval "(progn \
  (require 'package) \
  (setq package-user-dir \"~/tmp-cache\") \
  (add-to-list 'package-archives '(\"melpa\" . \"http://melpa.org/packages/\")) \
  (add-to-list 'package-archives '(\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\")) \
  (package-initialize) \
  (package-refresh-contents) \
  (package-install 'compat) \
  (print (mapcar #'package-desc-name (package-compute-transaction () (list (list 'git-commit))))))"
...
Package ‘compat’ installed.

(with-editor seq transient git-commit)
```