### PR TITLE
compat.texi: Fix references to Emacs 30.1 in Support section

### DIFF
--- a/compat.texi
+++ b/compat.texi
@@ -74,6 +74,7 @@ Support
 * Emacs 27.1::                   Compatibility support for Emacs 27.1
 * Emacs 28.1::                   Compatibility support for Emacs 28.1
 * Emacs 29.1::                   Compatibility support for Emacs 29.1
+* Emacs 30.1::                   Compatibility support for Emacs 30.1
 
 @end detailmenu
 @end menu
@@ -309,6 +310,7 @@ manage to provide for each Emacs version.
 * Emacs 27.1::                   Compatibility support for Emacs 27.1
 * Emacs 28.1::                   Compatibility support for Emacs 28.1
 * Emacs 29.1::                   Compatibility support for Emacs 29.1
+* Emacs 30.1::                   Compatibility support for Emacs 30.1
 @end menu
 
 @node Emacs 25.1


### PR DESCRIPTION
Fixes:

```
makeinfo compat.texi
compat.texi:2251: warning: node `Emacs 30.1' is next for `Emacs 29.1' in sectioning but not in menu
compat.texi:3316: warning: node `Emacs 29.1' is prev for `Emacs 30.1' in sectioning but not in menu
compat.texi:3316: warning: node `Support' is up for `Emacs 30.1' in sectioning but not in menu
compat.texi:300: node `Support' lacks menu item for `Emacs 30.1' despite being its Up target
make: *** [Makefile:116: compat.info] Error 1
```