### PR TITLE
Add string-glyph-compose and string-glyph-decompose

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -2,6 +2,10 @@
 #+link:    compat-gh   https://github.com/emacs-compat/compat/issues/
 #+options: toc:nil num:nil author:nil
 
+* Development
+
+- compat-29: Add =string-glyph-compose= and =string-glyph-decompose=.
+
 * Release of "Compat" Version 30.1.0.1
 
 - compat-28: Fix =named-let= tail recursion.

--- a/compat-29.el
+++ b/compat-29.el
@@ -641,6 +641,30 @@ The variable list SPEC is the same as in `if-let*'."
                ,@body)
            (throw ',done nil))))))
 
+;;;; Defined in ucs-normalize.el
+
+(compat-defun string-glyph-compose (string) ;; <compat-tests:string-glyph-compose>
+  "Compose STRING according to the Unicode NFC.
+This returns a new string obtained by canonical decomposition
+of STRING (see `ucs-normalize-NFC-string') followed by canonical
+composition, a.k.a. the \"Unicode Normalization Form C\" of STRING.
+For instance:
+
+  (string-glyph-compose \"Å\") => \"Å\""
+  (unless (fboundp 'ucs-normalize-NFC-string)
+    (require 'ucs-normalize))
+  (ucs-normalize-NFC-string string))
+
+(compat-defun string-glyph-decompose (string) ;; <compat-tests:string-glyph-decompose>
+  "Decompose STRING according to the Unicode NFD.
+This returns a new string that is the canonical decomposition of STRING,
+a.k.a. the \"Unicode Normalization Form D\" of STRING.  For instance:
+
+  (ucs-normalize-NFD-string \"Å\") => \"Å\""
+  (unless (fboundp 'ucs-normalize-NFD-string)
+    (require 'ucs-normalize))
+  (ucs-normalize-NFD-string string))
+
 ;;;; Defined in files.el
 
 (compat-defun directory-abbrev-make-regexp (directory) ;; <compat-tests:directory-abbrev-make-regexp>

--- a/compat-tests.el
+++ b/compat-tests.el
@@ -1946,6 +1946,12 @@
   (should-equal '("a" "b" "c") (split-string "a b c"))
   (should-equal '("a" "b" "c") (string-split "a b c")))
 
+(ert-deftest compat-string-glyph-decompose ()
+  (should-equal 10 (length (string-to-list (string-glyph-decompose "àèìòù")))))
+
+(ert-deftest compat-string-glyph-compose ()
+  (should-equal "àèìòù" (string-glyph-compose (string-glyph-decompose "àèìòù"))))
+
 (ert-deftest compat-string-equal-ignore-case ()
   (should (string-equal-ignore-case "abc" "abc"))
   (should (string-equal-ignore-case "abc" "ABC"))

--- a/compat.texi
+++ b/compat.texi
@@ -2683,6 +2683,27 @@ you can say:
 @xref{Size of Displayed Text,,,elisp}.
 @end defun
 
+@c copied from lisp/international/ucs-normalize.el
+@defun string-glyph-compose string
+Compose @var{string} according to the Unicode NFC.
+This returns a new string obtained by canonical decomposition
+of @var{string} (see @code{ucs-normalize-NFC-string}) followed by
+canonical composition, a.k.a. the \"Unicode Normalization Form C\"
+of @var{string}.  For instance:
+
+  @code{(string-glyph-compose \"Å\") => \"Å\"}
+@end defun
+
+@c copied from lisp/international/ucs-normalize.el
+@defun string-glyph-decompose string
+Decompose @var{string} according to the Unicode NFD.
+This returns a new string that is the canonical decomposition
+of @var{string}, a.k.a. the \"Unicode Normalization Form D\"
+of @var{string}.  For instance:
+
+  @code{(ucs-normalize-NFD-string \"Å\") => \"Å\""}
+@end defun
+
 @c based on lisp/emacs-lisp/subr-x.el
 @defmac with-buffer-unmodified-if-unchanged &rest body@dots{}
 Evaluate @var{body} like @code{progn}, but change buffer-modified


### PR DESCRIPTION
Hi. Just following the general style, let me know if anything's amiss.  

I got FSF paperwork.

I can force-push some documentation if/after you okay this.

Actually, I'm not sure where to call `(require 'ucs-normalize)`, but AFAIK, the `ucs-normalize-NF{C,D}-string` functions are autoloaded anyway up to and including Emacs 28, and from 29 on it would be moot.  But I'll double-check that soon.