### PR TITLE
Add no-byte-compile cookie to .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,4 @@
-;;; Directory Local Variables
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
 ;;; For more information see (info "(emacs) Directory Variables")
 
 ((emacs-lisp-mode


### PR DESCRIPTION
To fix native compiler error:

```
⛔ Warning (native-compiler): Error: native-compiler-error-empty-byte ("/home/bandali/.emacs.d/lisp/compat/.dir-locals.el" "/home/bandali/.emacs.d/lisp/compat/.dir-locals.el")
```